### PR TITLE
[feat] 최근 본 상품 추가 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation("io.jsonwebtoken:jjwt-api:0.12.6")
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/controller/ProductPostController.java
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/controller/ProductPostController.java
@@ -2,8 +2,10 @@ package com.NBE_4_5_2.Team5.domain.post.post.controller;
 
 import com.NBE_4_5_2.Team5.domain.post.post.dto.request.ProductPostModifyForm;
 import com.NBE_4_5_2.Team5.domain.post.post.dto.request.ProductPostWriteForm;
+import com.NBE_4_5_2.Team5.domain.post.post.dto.response.PreviewPostResponse;
 import com.NBE_4_5_2.Team5.domain.post.post.dto.response.ProductPostResponse;
 import com.NBE_4_5_2.Team5.domain.post.post.service.ProductPostService;
+import com.NBE_4_5_2.Team5.domain.post.post.service.RecentlyViewedService;
 import com.NBE_4_5_2.Team5.domain.user.entity.User;
 import com.NBE_4_5_2.Team5.global.Rq;
 import com.NBE_4_5_2.Team5.global.dto.Empty;
@@ -14,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
-import java.io.Reader;
+import java.util.List;
 
 
 @RestController
@@ -22,6 +24,7 @@ import java.io.Reader;
 @RequiredArgsConstructor
 public class ProductPostController {
     private final ProductPostService productPostService;
+    private final RecentlyViewedService recentlyViewedService;
     private final Rq rq;
 
     @PostMapping
@@ -39,11 +42,11 @@ public class ProductPostController {
 
     @GetMapping
     @Transactional(readOnly = true)
-    public RsData<PageDto<ProductPostResponse>> getPosts(@RequestParam(defaultValue = "1") int page,
+    public RsData<PageDto<PreviewPostResponse>> getPosts(@RequestParam(defaultValue = "1") int page,
                                                          @RequestParam(defaultValue = "10") int pageSize,
                                                          @RequestParam(defaultValue = "") String keyword,
                                                          @RequestParam(defaultValue = "desc") String sort) {
-        PageDto<ProductPostResponse> postPage = productPostService.getPosts(page, pageSize, keyword, sort);
+        PageDto<PreviewPostResponse> postPage = productPostService.getPosts(page, pageSize, keyword, sort);
 
         return new RsData<>(
                 "200",
@@ -54,11 +57,11 @@ public class ProductPostController {
 
     @GetMapping("/my")
     @Transactional(readOnly = true)
-    public RsData<PageDto<ProductPostResponse>> getMyPosts(@RequestParam(defaultValue = "1") int page,
+    public RsData<PageDto<PreviewPostResponse>> getMyPosts(@RequestParam(defaultValue = "1") int page,
                                                            @RequestParam(defaultValue = "10") int pageSize,
                                                            @RequestParam(defaultValue = "desc") String sort) {
         User actor = rq.getUserIdentity();
-        PageDto<ProductPostResponse> postPage = productPostService.getMyPosts(actor, page, pageSize, sort);
+        PageDto<PreviewPostResponse> postPage = productPostService.getMyPosts(actor, page, pageSize, sort);
 
         return new RsData<>(
                 "200",
@@ -69,13 +72,30 @@ public class ProductPostController {
 
     @GetMapping("/{id}")
     @Transactional(readOnly = true)
-    public RsData<ProductPostResponse> getPost(@PathVariable String id, Reader reader) {
+    public RsData<ProductPostResponse> getPost(@PathVariable String id) {
+        User user = rq.getUserIdentity();
         ProductPostResponse postResponse = productPostService.getPost(id);
+
+        recentlyViewedService.addViewedPost(user.getId(), id);
 
         return new RsData<>(
                 "200",
                 "게시물 조회가 완료되었습니다.",
                 postResponse
+        );
+    }
+
+    @GetMapping("/recently-viewed")
+    @Transactional(readOnly = true)
+    public RsData<List<PreviewPostResponse>> getRecentlyViewPosts() {
+
+        User user = rq.getUserIdentity();
+        List<PreviewPostResponse> recentlyViewedPosts = recentlyViewedService.getRecentlyViewedPosts(user.getId());
+
+        return new RsData<>(
+                "200",
+                "최근 본 상품 목록 조회가 완료되었습니다.",
+                recentlyViewedPosts
         );
     }
 

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/dto/response/PreviewPostResponse.java
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/dto/response/PreviewPostResponse.java
@@ -1,0 +1,40 @@
+package com.NBE_4_5_2.Team5.domain.post.post.dto.response;
+
+import com.NBE_4_5_2.Team5.domain.post.post.entity.ProductPost;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class PreviewPostResponse {
+    private String id;
+    private String productName;
+    private Integer productPrice;
+    private String title;
+    private String writerId;
+    private String writerName;
+    private Float latitude;
+    private Float longitude;
+    private String thumbNail;
+    private LocalDateTime createdAt;
+
+    public static PreviewPostResponse fromEntity(ProductPost post) {
+        return PreviewPostResponse.builder()
+                .id(post.getId())
+                .productName(post.getProductName())
+                .productPrice(post.getProductPrice())
+                .title(post.getTitle())
+                .writerId(post.getWriter().getId())
+                .writerName(post.getWriter().getNickname())
+                .latitude(post.getLatitude())
+                .longitude(post.getLongitude())
+                .thumbNail(post.getImage_urls().split(",")[0])
+                .createdAt(post.getCreatedAt())
+                .build();
+    }
+
+}

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/dto/response/ProductPostResponse.java
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/dto/response/ProductPostResponse.java
@@ -26,7 +26,7 @@ public class ProductPostResponse {
         return new ProductPostResponse(
                 post.getId(),
                 post.getWriter().getId(),
-                post.getWriter().getNickname(),
+                post.getWriter().getUsername(),
                 post.getProductName(),
                 post.getProductPrice(),
                 post.getTitle(),

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/repository/ProductPostRepository.java
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/repository/ProductPostRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ProductPostRepository extends JpaRepository<ProductPost, String> {
 
@@ -23,4 +25,6 @@ public interface ProductPostRepository extends JpaRepository<ProductPost, String
 
     @EntityGraph(attributePaths = {"productCategories.category"})
     Page<ProductPost> findByWriter(User writer, Pageable pageable);
+
+    List<ProductPost> findByIdIn(List<String> postIds);
 }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/service/ProductPostService.java
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/service/ProductPostService.java
@@ -4,6 +4,7 @@ import com.NBE_4_5_2.Team5.domain.category.entity.Category;
 import com.NBE_4_5_2.Team5.domain.category.repository.CategoryRepository;
 import com.NBE_4_5_2.Team5.domain.post.post.dto.request.ProductPostModifyForm;
 import com.NBE_4_5_2.Team5.domain.post.post.dto.request.ProductPostWriteForm;
+import com.NBE_4_5_2.Team5.domain.post.post.dto.response.PreviewPostResponse;
 import com.NBE_4_5_2.Team5.domain.post.post.dto.response.ProductPostResponse;
 import com.NBE_4_5_2.Team5.domain.post.post.entity.ProductCategory;
 import com.NBE_4_5_2.Team5.domain.post.post.entity.ProductPost;
@@ -58,7 +59,7 @@ public class ProductPostService {
     }
 
 
-    public PageDto<ProductPostResponse> getPosts(int page, int pageSize, String keyword, String sort) {
+    public PageDto<PreviewPostResponse> getPosts(int page, int pageSize, String keyword, String sort) {
         Sort.Direction sortDirection = sort.equalsIgnoreCase("asc") ? Sort.Direction.ASC : Sort.Direction.DESC;
         Pageable pageable = PageRequest.of(page - 1, pageSize,
                 Sort.by(sortDirection, "createdAt"));
@@ -72,19 +73,19 @@ public class ProductPostService {
             postpage = productPostRepository.findByTitleLike(likeKeyword, pageable);
         }
 
-        Page<ProductPostResponse> mappedPosts = postpage.map(ProductPostResponse::fromEntity);
+        Page<PreviewPostResponse> mappedPosts = postpage.map(PreviewPostResponse::fromEntity);
 
         return new PageDto<>(mappedPosts);
     }
 
-    public PageDto<ProductPostResponse> getMyPosts(User actor, int page, int pageSize, String sort) {
+    public PageDto<PreviewPostResponse> getMyPosts(User actor, int page, int pageSize, String sort) {
         Sort.Direction sortDirection = sort.equalsIgnoreCase("asc") ? Sort.Direction.ASC : Sort.Direction.DESC;
         Pageable pageable = PageRequest.of(page - 1, pageSize,
                 Sort.by(sortDirection, "createdAt"));
 
         Page<ProductPost> postPage = productPostRepository.findByWriter(actor, pageable);
 
-        Page<ProductPostResponse> mappedMyPosts = postPage.map(ProductPostResponse::fromEntity);
+        Page<PreviewPostResponse> mappedMyPosts = postPage.map(PreviewPostResponse::fromEntity);
 
         return new PageDto<>(mappedMyPosts);
     }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/service/RecentlyViewedService.java
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/post/post/service/RecentlyViewedService.java
@@ -1,0 +1,46 @@
+package com.NBE_4_5_2.Team5.domain.post.post.service;
+
+import com.NBE_4_5_2.Team5.domain.post.post.dto.response.PreviewPostResponse;
+import com.NBE_4_5_2.Team5.domain.post.post.entity.ProductPost;
+import com.NBE_4_5_2.Team5.domain.post.post.repository.ProductPostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RecentlyViewedService {
+    private final String RECENTLY_VIEW_KEY = "recentlyViewed:";
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ProductPostRepository productPostRepository;
+
+    // 최신순 -> 큐
+    public void addViewedPost(String userId, String postId) {
+        String key = RECENTLY_VIEW_KEY + userId;
+        ListOperations<String, String> listOps = redisTemplate.opsForList();
+
+        listOps.remove(key, 1, postId);
+        listOps.leftPush(key, postId);
+
+        System.out.println(listOps.getFirst(key));
+
+        if (listOps.size(key) > 10) {
+            listOps.rightPop(key);
+        }
+    }
+
+    public List<PreviewPostResponse> getRecentlyViewedPosts(String userId) {
+        String key = RECENTLY_VIEW_KEY + userId;
+        List<String> postIds = Optional.ofNullable(redisTemplate.opsForList().range(key, 0, -1))
+                .orElse(Collections.emptyList());
+
+        List<ProductPost> posts = productPostRepository.findByIdIn(postIds);
+
+        return posts.stream().map(PreviewPostResponse::fromEntity).toList();
+    }
+}


### PR DESCRIPTION
## 구현 내용
* Redis를 사용하여 10개이하만 저장

* docker를 통해 redis 작동
```shell
docker run --name redis -d -p 6379:6379 redis
```
* 게시물 상세 조회가 아닌 경우에는 PreviewPostResponse dto 사용
* 유저가 게시물 단건 조회 시, 최신 본 상품 배열에 추가된다

## 최근 본 상품 목록 조회 (GET /recently-viewed) 구현 내용
* 유저의 정보를 가져온다
* getRecentlyViewedPosts를 통해 특정 유저가 본 상품 글을 조회하고 dto로 변환한다
* 리스트로 반환




