### PR TITLE
옥정현/fix 87 refresh api 로직 수정

### DIFF
--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/controller/UserController.java
@@ -82,19 +82,14 @@ public class UserController {
 
     record RefreshUserForm(@NotBlank(message = "refreshToken을 입력해주세요.") String refreshToken) {}
 
-    @PreAuthorize("isAuthenticated()")
     @PostMapping("/refresh")
     public RsData<String> refreshAccessToken(@RequestBody @Valid RefreshUserForm userForm) {
 
-        User userIdentity = rq.getUserIdentity();
-        userService.validateRefreshToken(userIdentity, userForm.refreshToken());
+        String refreshToken = userForm.refreshToken();
+        String newAccessToken = userService.refreshAccessToken(refreshToken);
+        rq.addCookie("accessToken", newAccessToken);
 
-        User user = rq.getRealActor(userIdentity);
-
-        AuthToken newAuthToken = userService.generateAuthtoken(user);
-        rq.addCookie("accessToken", newAuthToken.accessToken());
-
-        return new RsData<>("200-1", "AccessToken이 재발급되었습니다.", newAuthToken.accessToken());
+        return new RsData<>("200-1", "AccessToken이 재발급되었습니다.", newAccessToken);
     }
 
     //  내 정보 수정

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/service/UserService.java
@@ -131,7 +131,7 @@ public class UserService {
         Optional<RefreshToken> tokenByRefreshToken = redisService.getTokenByRefreshToken(refreshToken);
 
         if (tokenByRefreshToken.isEmpty()) {
-            throw new ServiceException("400-1", "유효하지 않은 refreshToken입니다.");
+            throw new ServiceException("401-1", "유효하지 않은 RefreshToken입니다.");
         }
 
         String userId = tokenByRefreshToken.get().getUserId().substring("refreshToken:".length());

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/domain/user/service/UserService.java
@@ -121,22 +121,25 @@ public class UserService {
     }
 
     /**
-     * refreshToken 검증
+     * refreshToken 검증 및 accessToken 재발급
      *
-     * @param user         로그인한 사용자
-     * @param refreshToken 검증할 refreshToken
-     * @throws ServiceException 사용자의 userId로 된 refreshToken이 존재하지 않거나 값이 일치하지 않을 경우
+     * @param refreshToken 재발급에 사용할 refreshToken
+     * @throws ServiceException 유효하지 않은 token 혹은 존재하지 않는 회원의 token인 경우(탈퇴)
      */
-    public void validateRefreshToken(User user, String refreshToken) {
-        String userId = user.getId();
+    public String refreshAccessToken(String refreshToken) {
 
-        String storedRefreshToken = redisService.getTokenByUserId(userId)
-                .map(RefreshToken::getRefreshToken)
-                .orElseThrow(() -> new ServiceException("401-1", "로그인이 필요합니다."));
+        Optional<RefreshToken> tokenByRefreshToken = redisService.getTokenByRefreshToken(refreshToken);
 
-        if (!storedRefreshToken.equals(refreshToken)) {
-            throw new ServiceException("401-2", "유효하지 않은 RefreshToken입니다.");
+        if (tokenByRefreshToken.isEmpty()) {
+            throw new ServiceException("400-1", "유효하지 않은 refreshToken입니다.");
         }
+
+        String userId = tokenByRefreshToken.get().getUserId().substring("refreshToken:".length());
+        redisService.deleteTokenByUserId(userId);
+
+        return userRepository.findById(userId)
+                .map(authTokenService::generateAccessToken)
+                .orElseThrow(() -> new ServiceException("404-1", "존재하지 않는 회원의 refreshToken입니다."));
     }
 
     /**
@@ -252,5 +255,4 @@ public class UserService {
     public void deleteMyProfile(User user) {
         userRepository.delete(user);
     }
-
 }

--- a/backend/src/main/java/com/NBE_4_5_2/Team5/global/security/CustomAuthenticationFilter.java
+++ b/backend/src/main/java/com/NBE_4_5_2/Team5/global/security/CustomAuthenticationFilter.java
@@ -27,7 +27,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String url = request.getRequestURI();
-        if (List.of("/api/users/login", "/api/users/signup", "/error").contains(url)) {
+        if (List.of("/api/users/login", "/api/users/signup", "/api/users/refresh" , "/error").contains(url)) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/NBE_4_5_2/Team5/domain/user/controller/UserControllerTest.java
@@ -692,11 +692,10 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.message").value("로그인이 필요합니다."));
     }
 
-    private ResultActions refreshAccessTokenHeaderRequest(String refreshToken, String token) throws Exception {
+    private ResultActions refreshAccessTokenRequest(String refreshToken) throws Exception {
         return mvc
                 .perform(
                         post("/api/users/refresh")
-                                .header("Authorization", "Bearer " + token)
                                 .content("""
                                         {
                                           "refreshToken": "%s"
@@ -712,10 +711,10 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("토큰 재발급 - 성공 - 헤더 인증")
+    @DisplayName("토큰 재발급 - 성공")
     void refreshAccessToken1() throws Exception {
 
-        ResultActions resultActions = refreshAccessTokenHeaderRequest(validRefreshToken, validToken);
+        ResultActions resultActions = refreshAccessTokenRequest(validRefreshToken);
 
         resultActions
                 .andExpect(status().isOk())
@@ -764,7 +763,7 @@ class UserControllerTest {
     @DisplayName("토큰 재발급 - 실패 - refreshToken이 빈 문자열")
     void refreshAccessToken3() throws Exception {
         String token = " ";
-        ResultActions resultActions = refreshAccessTokenHeaderRequest(token, validToken);
+        ResultActions resultActions = refreshAccessTokenRequest(token);
 
         resultActions
                 .andExpect(status().isBadRequest())
@@ -777,11 +776,11 @@ class UserControllerTest {
     void refreshAccessToken4() throws Exception {
         String fakeRefreshToken = "invalid_refresh_token";
 
-        ResultActions resultActions = refreshAccessTokenHeaderRequest(fakeRefreshToken, validToken);
+        ResultActions resultActions = refreshAccessTokenRequest(fakeRefreshToken);
 
         resultActions
                 .andExpect(status().isUnauthorized())
-                .andExpect(jsonPath("$.code").value("401-2"))
+                .andExpect(jsonPath("$.code").value("401-1"))
                 .andExpect(jsonPath("$.message").value("유효하지 않은 RefreshToken입니다."));
     }
 

--- a/frontend/src/lib/backend/apiV1/schema.d.ts
+++ b/frontend/src/lib/backend/apiV1/schema.d.ts
@@ -52,6 +52,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chat/admin": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put: operations["grantAdmin"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/users/signup": {
         parameters: {
             query?: never;
@@ -116,6 +132,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/uploadFile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["uploadFile"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/posts": {
         parameters: {
             query?: never;
@@ -158,6 +190,38 @@ export interface paths {
         get?: never;
         put?: never;
         post: operations["purchaseItem"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chat/room": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["createRoom"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chat/admin/{adminId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["createRoomAdmin"];
         delete?: never;
         options?: never;
         head?: never;
@@ -308,6 +372,70 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/chat/user": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getUserInfo"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chat/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["findChatRooms"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chat/rooms": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getUserRooms"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/chat/message": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getMessages"];
+        put?: never;
+        post?: never;
+        delete: operations["deleteRoom"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/categories": {
         parameters: {
             query?: never;
@@ -423,6 +551,83 @@ export interface components {
             message: string;
             data: components["schemas"]["ProductPostResponse"];
         };
+        Category: {
+            /** Format: int64 */
+            id?: number;
+            name?: string;
+        };
+        Comment: {
+            id?: string;
+            content?: string;
+            target?: components["schemas"]["ProductPost"];
+            author?: components["schemas"]["User"];
+        };
+        GrantedAuthority: {
+            authority?: string;
+        };
+        ProductCategory: {
+            /** Format: int64 */
+            id?: number;
+            productPost?: components["schemas"]["ProductPost"];
+            category?: components["schemas"]["Category"];
+        };
+        ProductPost: {
+            id?: string;
+            productName?: string;
+            /** Format: int32 */
+            productPrice?: number;
+            buyer?: components["schemas"]["User"];
+            title?: string;
+            content?: string;
+            image_urls?: string;
+            /** Format: int32 */
+            likedCount?: number;
+            /** @enum {string} */
+            status?: "RESERVED" | "AVAILABLE" | "PURCHASED";
+            /** Format: float */
+            latitude?: number;
+            /** Format: float */
+            longitude?: number;
+            /** Format: date-time */
+            createdAt?: string;
+            /** Format: date-time */
+            modifiedAt?: string;
+            productCategories?: components["schemas"]["ProductCategory"][];
+            writer?: components["schemas"]["User"];
+            commentList?: components["schemas"]["Comment"][];
+            available?: boolean;
+        };
+        RsDataUser: {
+            code: string;
+            message: string;
+            data: components["schemas"]["User"];
+        };
+        User: {
+            id?: string;
+            /** Format: date-time */
+            createdAt?: string;
+            /** Format: date-time */
+            modifiedAt?: string;
+            username?: string;
+            password?: string;
+            email?: string;
+            nickname?: string;
+            address?: string;
+            profileUrl?: string;
+            /** Format: int32 */
+            cash?: number;
+            /** @enum {string} */
+            role?: "ADMIN" | "USER";
+            blocked?: boolean;
+            /** Format: int32 */
+            blockedCount?: number;
+            purchasedProducts?: components["schemas"]["ProductPost"][];
+            writtenProducts?: components["schemas"]["ProductPost"][];
+            wroteComments?: components["schemas"]["Comment"][];
+            admin?: boolean;
+            authorities?: components["schemas"]["GrantedAuthority"][];
+            memberAuthoritiesAsString?: string[];
+        };
         SignUpUserForm: {
             username?: string;
             password?: string;
@@ -498,6 +703,21 @@ export interface components {
             code: string;
             message: string;
             data: components["schemas"]["PaymentDto"];
+        };
+        ChatRoom: {
+            id?: string;
+            roomId?: string;
+            name?: string;
+            sender?: string;
+            receiver?: string;
+            client?: string;
+            /** Format: int64 */
+            userCount?: number;
+        };
+        RsDataChatRoom: {
+            code: string;
+            message: string;
+            data: components["schemas"]["ChatRoom"];
         };
         BanReqBody: {
             reason: string;
@@ -591,10 +811,37 @@ export interface components {
             message: string;
             data: components["schemas"]["PaymentMetaData"];
         };
-        Category: {
-            /** Format: int64 */
-            id?: number;
+        AccessProvider: {
             name?: string;
+            token?: string;
+        };
+        RsDataAccessProvider: {
+            code: string;
+            message: string;
+            data: components["schemas"]["AccessProvider"];
+        };
+        ChatRoomDto: {
+            postId?: string;
+            roomId?: string;
+            name?: string;
+            /** Format: int64 */
+            userCount?: number;
+        };
+        RsDataListChatRoomDto: {
+            code: string;
+            message: string;
+            data: components["schemas"]["ChatRoomDto"][];
+        };
+        MessageDto: {
+            sender?: string;
+            message?: string;
+            image?: string;
+            timestamp?: string;
+        };
+        RsDataListMessageDto: {
+            code: string;
+            message: string;
+            data: components["schemas"]["MessageDto"][];
         };
         RsDataListCategory: {
             code: string;
@@ -875,6 +1122,37 @@ export interface operations {
             };
         };
     };
+    grantAdmin: {
+        parameters: {
+            query: {
+                userId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataUser"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
     createUser: {
         parameters: {
             query?: never;
@@ -990,6 +1268,42 @@ export interface operations {
                 };
                 content: {
                     "application/json;charset=UTF-8": components["schemas"]["RsDataLoginUserDto"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    uploadFile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** Format: binary */
+                    file: string;
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": string;
                 };
             };
             /** @description Internal Server Error */
@@ -1125,6 +1439,68 @@ export interface operations {
                 };
                 content: {
                     "application/json;charset=UTF-8": components["schemas"]["RsDataPaymentDto"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    createRoom: {
+        parameters: {
+            query: {
+                postId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataChatRoom"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    createRoomAdmin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                adminId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataChatRoom"];
                 };
             };
             /** @description Internal Server Error */
@@ -1407,6 +1783,157 @@ export interface operations {
                 };
                 content: {
                     "application/json;charset=UTF-8": components["schemas"]["RsDataPaymentMetaData"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    getUserInfo: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataAccessProvider"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    findChatRooms: {
+        parameters: {
+            query: {
+                receiver: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataString"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    getUserRooms: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataListChatRoomDto"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    getMessages: {
+        parameters: {
+            query: {
+                roomId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataListMessageDto"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataVoid"];
+                };
+            };
+        };
+    };
+    deleteRoom: {
+        parameters: {
+            query: {
+                roomId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json;charset=UTF-8": components["schemas"]["RsDataString"];
                 };
             };
             /** @description Internal Server Error */


### PR DESCRIPTION
## 📌 과제 설명 
refresh api를 통해 accessToken을 정상적으로 발급받을 수 있도록 수정

## 👩‍💻 요구 사항과 구현 내용
- **Refresh API 접근 권한 수정**  
  - @PreAuthorize("isAuthenticated()") 제거

- **RefreshToken 검증 과정 수정**  
  - refresh API 요청 시 filter 과정에서 이미 토큰 재발급이 완료가 되어 사용자가 body에 넣어 요청한 refreshToken이 이미 만료되버리는 문제 발생
  - 이를 해결하기 위해 **body로 전달된 refreshToken을 기반으로 직접 유저 정보를 조회**하고 재발급해주도록 수정




